### PR TITLE
Issue/48 player rotation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,13 @@ impl Player {
             self.direction.0 += Self::TWO_PI
         }
     }
+
+    fn rotate_pitch(&mut self, angle: f32) {
+        let new = self.direction.1 + angle;
+
+        // Clamp pitch to max out at looking up or down
+        self.direction.1 = new.clamp(-std::f32::consts::FRAC_PI_2, std::f32::consts::FRAC_PI_2);
+    }
 }
 
 impl State {

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,8 @@ enum Direction {
 }
 
 impl Player {
+    const TWO_PI: f32 = std::f32::consts::PI * 2.0;
+    
     fn move_in_direction(&mut self, direction: Direction, step: f32) {
         let quarter_rotation = std::f32::consts::FRAC_PI_2;
         let (dx, dz) = match direction {
@@ -127,6 +129,17 @@ impl Player {
 
     fn move_down(&mut self, step: f32) {
         self.position.y -= step;
+    }
+
+    fn rotate_yaw(&mut self, angle: f32) { 
+        self.direction.0 += angle;
+
+        // Wrap the rotation to prevent it from getting too large
+        if self.direction.0 > Self::TWO_PI {
+            self.direction.0 -= Self::TWO_PI
+        } else if self.direction.0 < Self::TWO_PI {
+            self.direction.0 += Self::TWO_PI
+        }
     }
 }
 


### PR DESCRIPTION
Implement functions for player rotation, that limits the rotation values from getting to big, and prevents player to be able to look behind by rotating up.